### PR TITLE
Merge bmcd_dev_20250916: Subtitle embedding and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v0.5.8-bmcd04] - 2025-11-13
+
+### Added
+- **Subtitle Embedding Feature** - Added ability to embed downloaded subtitles directly into MP4 video files
+  - New `add_subtitles` configuration option in Downloads settings
+  - Implemented FFmpegEmbedSubtitle postprocessor in yt-dlp handler
+  - Added toggle control in Settings → Application page
+  - Subtitle embedding is disabled by default for backwards compatibility
+  - Commits: cf3b3891
+
+### Fixed
+- **Query Variable Bug** - Fixed incorrect variable reference (`query` → `queries`) in channel video query logic that could cause AttributeError
+  - File: `backend/channel/src/remote_query.py`
+  - Commits: 47b4332e
+
+- **Download Progress Safety** - Added defensive programming to prevent KeyError when processing yt-dlp responses
+  - Now uses `.get()` method with fallback to "Processing" instead of direct dictionary access
+  - Prevents crashes when `info_dict` or `title` is unavailable during download progress updates
+  - File: `backend/download/src/yt_dlp_handler.py`
+  - Commits: c7905309
+
+### Changed
+- **Frontend Tooling** - Added missing `@eslint/js` v9.33.0 dependency for ESLint support
+  - Improved code formatting consistency
+  - Commits: c800c278
+
+### Technical Details
+
+#### Files Modified
+**Backend:**
+- `backend/appsettings/serializers.py` - Added `add_subtitles` field
+- `backend/appsettings/src/config.py` - Added subtitle embedding configuration
+- `backend/download/src/yt_dlp_handler.py` - Implemented subtitle embedding logic and safety improvements
+- `backend/channel/src/remote_query.py` - Fixed variable reference bug
+
+**Frontend:**
+- `frontend/package.json` - Added @eslint/js dependency
+- `frontend/package-lock.json` - Updated lockfile
+- `frontend/src/api/loader/loadAppsettingsConfig.ts` - Added TypeScript type for add_subtitles
+- `frontend/src/stores/AppSettingsStore.ts` - Added state management for subtitle embedding
+- `frontend/src/pages/SettingsApplication.tsx` - Added UI toggle and formatting improvements
+
+#### Migration Notes
+- No database migrations required
+- New `add_subtitles` setting defaults to `false` (disabled)
+- Existing configurations will continue to work without changes
+
+## [v0.5.8-bmcd03] - 2025-09-XX
+
+### Added
+- Thread-safe startup timestamp handling
+- Full metadata embedding functionality
+- Deno support added to build process
+- Frontend caching reload improvements
+
+### Changed
+- Bumped Django version for security updates
+- Updated frontend dependencies
+- Pinned yt-dlp to master branch
+
+### Fixed
+- Fixed unittest failures in startup timestamp handling
+- Fixed embed error handling
+- Fixed upload_date format handling (#1052)
+
+---
+
+## Previous Versions
+
+For changes in versions prior to v0.5.8-bmcd03, please refer to the git commit history or original upstream repository.
+
+---
+
+**Note:** This changelog tracks changes specific to the bmcdonough fork. For upstream Tube Archivist changes, see the [official repository](https://github.com/tubearchivist/tubearchivist).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.5.8-bmcd04] - 2025-11-13
+## [v0.5.8-bmcd01] - 2025-11-13
 
 ### Added
 - **Subtitle Embedding Feature** - Added ability to embed downloaded subtitles directly into MP4 video files
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `add_subtitles` setting defaults to `false` (disabled)
 - Existing configurations will continue to work without changes
 
-## [v0.5.8-bmcd03] - 2025-09-XX
+## [v0.5.8] - 2025-11-07
 
 ### Added
 - Thread-safe startup timestamp handling

--- a/backend/appsettings/serializers.py
+++ b/backend/appsettings/serializers.py
@@ -44,6 +44,7 @@ class AppConfigDownloadsSerializer(
     format = serializers.CharField(allow_null=True)
     format_sort = serializers.CharField(allow_null=True)
     add_metadata = serializers.BooleanField()
+    add_subtitles = serializers.BooleanField()
     add_thumbnail = serializers.BooleanField()
     subtitle = serializers.CharField(allow_null=True)
     subtitle_source = serializers.ChoiceField(

--- a/backend/appsettings/src/config.py
+++ b/backend/appsettings/src/config.py
@@ -35,6 +35,7 @@ class DownloadsConfigType(TypedDict):
     format: str | None
     format_sort: str | None
     add_metadata: bool
+    add_subtitles: bool
     add_thumbnail: bool
     subtitle: str | None
     subtitle_source: Literal["user", "auto"] | None
@@ -85,6 +86,7 @@ class AppConfig:
             "format": None,
             "format_sort": None,
             "add_metadata": False,
+            "add_subtitles": False,
             "add_thumbnail": False,
             "subtitle": None,
             "subtitle_source": None,

--- a/backend/channel/src/remote_query.py
+++ b/backend/channel/src/remote_query.py
@@ -113,7 +113,7 @@ def get_last_channel_videos(
 
     last_videos: list[dict] = []
 
-    if not query:
+    if not queries:
         return last_videos
 
     for vid_type_enum, limit_amount in queries:

--- a/backend/download/src/yt_dlp_handler.py
+++ b/backend/download/src/yt_dlp_handler.py
@@ -161,9 +161,11 @@ class VideoDownloader(DownloaderBase):
             "progress_hooks": [self._progress_hook],
             "noprogress": True,
             "continuedl": True,
+            "writesubtitles": False,
             "writethumbnail": False,
             "noplaylist": True,
             "color": "no_color",
+            "subtitleslangs": [],
         }
 
     def _build_obs_user(self):
@@ -215,6 +217,16 @@ class VideoDownloader(DownloaderBase):
                 }
             )
             self.obs["writethumbnail"] = True
+
+        if self.config["downloads"]["add_subtitles"]:
+            postprocessors.append(
+                {
+                    "key": "FFmpegEmbedSubtitle",
+                    "already_have_subtitle": True,
+                }
+            )
+            self.obs["subtitleslangs"] = [self.config["downloads"]["subtitle"]]
+            self.obs["writesubtitles"] = True
 
         self.obs["postprocessors"] = postprocessors
 

--- a/backend/download/src/yt_dlp_handler.py
+++ b/backend/download/src/yt_dlp_handler.py
@@ -144,7 +144,8 @@ class VideoDownloader(DownloaderBase):
             message = "processing"
 
         if self.task:
-            title = response["info_dict"]["title"]
+            info_dict = response.get("info_dict", {})
+            title = info_dict.get("title", "Processing")
             self.task.send_progress([title, message], progress=progress)
 
     def _build_obs(self):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "zustand": "^5.0.7"
       },
       "devDependencies": {
+        "@eslint/js": "^9.33.0",
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
         "@typescript-eslint/eslint-plugin": "^8.39.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "zustand": "^5.0.7"
   },
   "devDependencies": {
+    "@eslint/js": "^9.33.0",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@typescript-eslint/eslint-plugin": "^8.39.0",

--- a/frontend/src/api/loader/loadAppsettingsConfig.ts
+++ b/frontend/src/api/loader/loadAppsettingsConfig.ts
@@ -16,6 +16,7 @@ export type AppSettingsConfigType = {
     format: string | null;
     format_sort: string | null;
     add_metadata: boolean;
+    add_subtitles: boolean;
     add_thumbnail: boolean;
     subtitle: string | null;
     subtitle_source: string | null;

--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -549,9 +549,7 @@ const SettingsApplication = () => {
                       Indexing subtitles add the fulltext to the ES index. Not recommended on low
                       end hardware.
                     </li>
-                    <li>
-                      Embed subtitles adds the subtitles to the mp4 file.
-                    </li>
+                    <li>Embed subtitles adds the subtitles to the mp4 file.</li>
                   </ul>
                 </div>
               )}

--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -57,6 +57,7 @@ const SettingsApplication = () => {
   const [downloadsFormatSort, setDownloadsFormatSort] = useState<string | null>(null);
   const [downloadsExtractorLang, setDownloadsExtractorLang] = useState<string | null>(null);
   const [embedMetadata, setEmbedMetadata] = useState(false);
+  const [embedSubtitles, setEmbedSubtitles] = useState(false);
   const [embedThumbnail, setEmbedThumbnail] = useState(false);
 
   // Subtitles
@@ -115,6 +116,7 @@ const SettingsApplication = () => {
     setDownloadsFormatSort(appSettingsConfigData?.downloads.format_sort || null);
     setDownloadsExtractorLang(appSettingsConfigData?.downloads.extractor_lang || null);
     setEmbedMetadata(appSettingsConfigData?.downloads.add_metadata || false);
+    setEmbedSubtitles(appSettingsConfigData?.downloads.add_subtitles || false);
     setEmbedThumbnail(appSettingsConfigData?.downloads.add_thumbnail || false);
 
     // Subtitles
@@ -547,6 +549,9 @@ const SettingsApplication = () => {
                       Indexing subtitles add the fulltext to the ES index. Not recommended on low
                       end hardware.
                     </li>
+                    <li>
+                      Embed subtitles adds the subtitles to the mp4 file.
+                    </li>
                   </ul>
                 </div>
               )}
@@ -602,6 +607,16 @@ const SettingsApplication = () => {
                     <ToggleConfig
                       name="downloads.subtitle_index"
                       value={indexSubtitles}
+                      updateCallback={handleUpdateConfig}
+                    />
+                  </div>
+                  <div className="settings-box-wrapper">
+                    <div>
+                      <p>Embed Subtitles</p>
+                    </div>
+                    <ToggleConfig
+                      name="downloads.add_subtitles"
+                      value={embedSubtitles}
                       updateCallback={handleUpdateConfig}
                     />
                   </div>

--- a/frontend/src/stores/AppSettingsStore.ts
+++ b/frontend/src/stores/AppSettingsStore.ts
@@ -23,6 +23,7 @@ export const useAppSettingsStore = create<AppSettingsState>(set => ({
       format: null,
       format_sort: null,
       add_metadata: false,
+      add_subtitles: false,
       add_thumbnail: false,
       subtitle: null,
       subtitle_source: null,


### PR DESCRIPTION
## Summary

This PR merges 4 commits from `bmcd_dev_20250916` into `v0.5.8-bmcd03`:

- **New Feature:** Subtitle embedding capability - adds ability to embed downloaded subtitles directly into MP4 files
- **Bug Fixes:** Two defensive programming improvements to prevent crashes during download processing
- **Tooling:** Added missing ESLint dependency for frontend development

## Changes

### 1. Embed Subtitles Feature (cf3b389)
Adds the ability to embed downloaded subtitles directly into MP4 video files during the download process.

**Backend:**
- Added `add_subtitles` configuration option to downloads settings
- Implemented FFmpegEmbedSubtitle postprocessor in yt-dlp handler
- Configures subtitle language from downloads config

**Frontend:**
- Added toggle control for "Embed Subtitles" in Settings → Application
- Updated TypeScript types and state management
- Added help text explaining the feature

**Files modified:**
- `backend/appsettings/serializers.py`
- `backend/appsettings/src/config.py`
- `backend/download/src/yt_dlp_handler.py`
- `frontend/src/api/loader/loadAppsettingsConfig.ts`
- `frontend/src/stores/AppSettingsStore.ts`
- `frontend/src/pages/SettingsApplication.tsx`

### 2. Query Variable Fix (47b4332)
Fixed incorrect variable reference in channel video query logic.

**Change:** `if not query:` → `if not queries:`

**Files modified:**
- `backend/channel/src/remote_query.py`

### 3. Info Dict Safety Check (c790530)
Adds defensive programming to prevent KeyError when processing yt-dlp responses.

**Change:** Uses `.get()` method with fallback to "Processing" instead of direct dictionary access

**Files modified:**
- `backend/download/src/yt_dlp_handler.py`

### 4. ESLint Dependency Fix (c800c27)
Added missing `@eslint/js` dependency and fixed code formatting.

**Files modified:**
- `frontend/package.json`
- `frontend/package-lock.json`
- `frontend/src/pages/SettingsApplication.tsx`

## Test Plan

- [ ] Verify subtitle embedding works with various subtitle formats
- [ ] Test download progress display during edge cases (missing info_dict)
- [ ] Confirm channel query processing with various query types
- [ ] Validate frontend build with new ESLint dependency
- [ ] Test subtitle toggle in Settings page
- [ ] Verify backwards compatibility (subtitle embedding disabled by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)