### PR TITLE
Merge bmcd_dev_20250917: Enhanced media stream metadata display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,116 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v0.5.8-bmcd02] - 2025-11-13
+
+### Added
+- **Enhanced Media Stream Metadata Display** - Significantly improved media stream information on video pages
+  - Added subtitle stream detection and display
+  - Added thumbnail stream detection (attached_pic)
+  - Added language metadata for video, audio, and subtitle streams
+  - Improved conditional rendering in frontend for different stream types
+  - Better handling of streams without bitrate data
+  - Commits: 7d66f8bc
+
+### Changed
+- **Frontend Tooling** - Added missing `@eslint/js` v9.33.0 dependency for ESLint support
+  - Commits: c18aff4c
+
+### Technical Details
+
+#### Files Modified
+**Backend:**
+- `backend/video/serializers.py` - Updated StreamItemSerializer to support subtitle type and language field
+- `backend/video/src/media_streams.py` - Added subtitle/thumbnail extraction, language metadata
+
+**Frontend:**
+- `frontend/package.json` - Added @eslint/js dependency
+- `frontend/src/pages/Home.tsx` - Updated StreamType TypeScript definitions
+- `frontend/src/pages/Video.tsx` - Enhanced stream display with conditional rendering
+
+#### Benefits
+- Users can now see all embedded streams (video, audio, subtitles, thumbnails)
+- Language information helps identify multi-language content
+- More robust handling of various media container formats
+- Complements the subtitle embedding feature by showing which subtitles are present
+
+---
+
+## [v0.5.8-bmcd01] - 2025-11-13
+
+### Added
+- **Subtitle Embedding Feature** - Added ability to embed downloaded subtitles directly into MP4 video files
+  - New `add_subtitles` configuration option in Downloads settings
+  - Implemented FFmpegEmbedSubtitle postprocessor in yt-dlp handler
+  - Added toggle control in Settings → Application page
+  - Subtitle embedding is disabled by default for backwards compatibility
+  - Commits: cf3b3891
+
+### Fixed
+- **Query Variable Bug** - Fixed incorrect variable reference (`query` → `queries`) in channel video query logic that could cause AttributeError
+  - File: `backend/channel/src/remote_query.py`
+  - Commits: 47b4332e
+
+- **Download Progress Safety** - Added defensive programming to prevent KeyError when processing yt-dlp responses
+  - Now uses `.get()` method with fallback to "Processing" instead of direct dictionary access
+  - Prevents crashes when `info_dict` or `title` is unavailable during download progress updates
+  - File: `backend/download/src/yt_dlp_handler.py`
+  - Commits: c7905309
+
+### Changed
+- **Frontend Tooling** - Added missing `@eslint/js` v9.33.0 dependency for ESLint support
+  - Improved code formatting consistency
+  - Commits: c800c278
+
+### Technical Details
+
+#### Files Modified
+**Backend:**
+- `backend/appsettings/serializers.py` - Added `add_subtitles` field
+- `backend/appsettings/src/config.py` - Added subtitle embedding configuration
+- `backend/download/src/yt_dlp_handler.py` - Implemented subtitle embedding logic and safety improvements
+- `backend/channel/src/remote_query.py` - Fixed variable reference bug
+
+**Frontend:**
+- `frontend/package.json` - Added @eslint/js dependency
+- `frontend/package-lock.json` - Updated lockfile
+- `frontend/src/api/loader/loadAppsettingsConfig.ts` - Added TypeScript type for add_subtitles
+- `frontend/src/stores/AppSettingsStore.ts` - Added state management for subtitle embedding
+- `frontend/src/pages/SettingsApplication.tsx` - Added UI toggle and formatting improvements
+
+#### Migration Notes
+- No database migrations required
+- New `add_subtitles` setting defaults to `false` (disabled)
+- Existing configurations will continue to work without changes
+
+## [v0.5.8] - 2025-11-07
+
+### Added
+- Thread-safe startup timestamp handling
+- Full metadata embedding functionality
+- Deno support added to build process
+- Frontend caching reload improvements
+
+### Changed
+- Bumped Django version for security updates
+- Updated frontend dependencies
+- Pinned yt-dlp to master branch
+
+### Fixed
+- Fixed unittest failures in startup timestamp handling
+- Fixed embed error handling
+- Fixed upload_date format handling (#1052)
+
+---
+
+## Previous Versions
+
+For changes in versions prior to v0.5.8-bmcd03, please refer to the git commit history or original upstream repository.
+
+---
+
+**Note:** This changelog tracks changes specific to the bmcdonough fork. For upstream Tube Archivist changes, see the [official repository](https://github.com/tubearchivist/tubearchivist).

--- a/backend/video/serializers.py
+++ b/backend/video/serializers.py
@@ -53,11 +53,12 @@ class StreamItemSerializer(serializers.Serializer):
     """serialize stream item"""
 
     index = serializers.IntegerField()
-    codec = serializers.CharField()
-    bitrate = serializers.IntegerField()
-    type = serializers.ChoiceField(choices=["video", "audio"])
+    codec = serializers.CharField(required=False, allow_null=True)
+    bitrate = serializers.IntegerField(required=False)
+    type = serializers.ChoiceField(choices=["video", "audio", "subtitle"])
     width = serializers.IntegerField(required=False)
     height = serializers.IntegerField(required=False)
+    language = serializers.CharField(required=False)
 
 
 class SubtitleItemSerializer(serializers.Serializer):

--- a/backend/video/src/media_streams.py
+++ b/backend/video/src/media_streams.py
@@ -45,25 +45,37 @@ class MediaStreamExtractor:
             self._extract_video_metadata(stream)
         elif codec_type == "audio":
             self._extract_audio_metadata(stream)
+        elif codec_type == "subtitle":
+            self._extract_subtitle_metadata(stream)
         else:
             return
 
     def _extract_video_metadata(self, stream):
         """parse video metadata"""
-        if "bit_rate" not in stream:
-            # is probably thumbnail
-            return
-
-        self.metadata.append(
-            {
-                "type": "video",
-                "index": stream["index"],
-                "codec": stream["codec_name"],
-                "width": stream["width"],
-                "height": stream["height"],
-                "bitrate": int(stream["bit_rate"]),
-            }
-        )
+        if stream["disposition"]["attached_pic"] == 1:
+            self.metadata.append(
+                {
+                    "type": "thumbnail",
+                    "index": stream["index"],
+                    "codec": stream["codec_name"],
+                    "width": stream["width"],
+                    "height": stream["height"],
+                }
+            )
+        else:
+            self.metadata.append(
+                {
+                    "type": "video",
+                    "index": stream["index"],
+                    "codec": stream["codec_name"],
+                    "width": stream["width"],
+                    "height": stream["height"],
+                    "bitrate": int(stream.get("bit_rate", 0)),
+                    "language": stream.get("tags", {}).get(
+                        "language", "unknown"
+                    ),
+                }
+            )
 
     def _extract_audio_metadata(self, stream):
         """extract audio metadata"""
@@ -73,6 +85,19 @@ class MediaStreamExtractor:
                 "index": stream["index"],
                 "codec": stream.get("codec_name", "undefined"),
                 "bitrate": int(stream.get("bit_rate", 0)),
+                "language": stream.get("tags", {}).get("language", "unknown"),
+            }
+        )
+
+    def _extract_subtitle_metadata(self, stream):
+        """extract subtitle metadata"""
+        self.metadata.append(
+            {
+                "type": "subtitle",
+                "index": stream["index"],
+                "codec": stream.get("codec_name", "text"),
+                "bitrate": int(stream.get("bit_rate", 0)),
+                "language": stream.get("tags", {}).get("language", "unknown"),
             }
         )
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "zustand": "^5.0.7"
   },
   "devDependencies": {
+    "@eslint/js": "^9.33.0",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@typescript-eslint/eslint-plugin": "^8.39.0",

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -43,10 +43,11 @@ export type StatsType = {
 export type StreamType = {
   type: string;
   index: number;
-  codec: string;
+  codec?: string;
   width?: number;
   height?: number;
-  bitrate: number;
+  bitrate?: number;
+  language?: string;
 };
 
 export type Subtitles = {

--- a/frontend/src/pages/Video.tsx
+++ b/frontend/src/pages/Video.tsx
@@ -467,13 +467,23 @@ const Video = () => {
               video.streams.map(stream => {
                 return (
                   <p key={stream.index}>
-                    {capitalizeFirstLetter(stream.type)}: {stream.codec}{' '}
-                    {humanFileSize(stream.bitrate, useSiUnits)}/s
+                    {capitalizeFirstLetter(stream.type)}: {stream.codec}
+                    {stream.bitrate && (
+                      <>
+                        <span className="space-carrot">|</span>{' '}
+                        {`${humanFileSize(stream.bitrate, useSiUnits)}/s`}
+                      </>
+                    )}
                     {stream.width && (
                       <>
                         <span className="space-carrot">|</span> {stream.width}x{stream.height}
                       </>
-                    )}{' '}
+                    )}
+                    {stream.language && (
+                      <>
+                        <span className="space-carrot">|</span> {stream.language}
+                      </>
+                    )}
                   </p>
                 );
               })}


### PR DESCRIPTION
## Summary

This PR merges 2 commits from `bmcd_dev_20250917` into `v0.5.8-bmcd03`:

- **Enhanced Feature:** Improved media stream metadata display to include subtitles and thumbnails
- **Tooling:** Added missing ESLint dependency for frontend development

## Changes

### 1. Add Subtitle and Thumbnail Metadata to Video Summary (7d66f8b)

Significantly improves the media stream metadata extraction and display on the video page.

**Backend Changes:**

**Media Stream Extraction (`backend/video/src/media_streams.py`):**
- Added `_extract_subtitle_metadata()` method to parse embedded subtitle streams
- Enhanced `_extract_video_metadata()` to detect and extract thumbnail streams (attached_pic)
- Added language metadata extraction for video, audio, and subtitle streams
- Improved handling of missing `bit_rate` fields (defaults to 0)
- Distinguishes between video streams and thumbnail attachments

**API Serialization (`backend/video/serializers.py`):**
- Updated `StreamItemSerializer` to support subtitle type
- Added `language` field to stream items
- Made `codec` and `bitrate` fields optional to support thumbnails
- Changed type choices to include `"subtitle"` in addition to `"video"` and `"audio"`

**Frontend Changes:**

**Type Definitions (`frontend/src/pages/Home.tsx`):**
- Updated `StreamType` to include optional `language` field
- Made `codec` and `bitrate` optional to handle all stream types

**Video Page Display (`frontend/src/pages/Video.tsx`):**
- Enhanced stream display to show language information
- Made bitrate display conditional (only shown when available)
- Improved formatting with conditional rendering for width/height and language
- Better handles thumbnail and subtitle streams that may not have bitrate data

**Impact:**
- Users can now see embedded subtitle streams in the video metadata
- Thumbnail information is properly displayed
- Language information is shown for all stream types
- More robust handling of different stream types

**Files modified:**
- `backend/video/serializers.py`
- `backend/video/src/media_streams.py`
- `frontend/src/pages/Home.tsx`
- `frontend/src/pages/Video.tsx`

### 2. ESLint Dependency Fix (c18aff4)

Added missing `@eslint/js` v9.33.0 dependency for ESLint support.

**Files modified:**
- `frontend/package.json`

## Test Plan

- [ ] Verify video metadata displays correctly for videos with multiple streams
- [ ] Test display of embedded subtitles in stream metadata
- [ ] Confirm thumbnail streams are properly identified and displayed
- [ ] Verify language information appears for audio and subtitle tracks
- [ ] Test videos without bitrate metadata render correctly
- [ ] Validate frontend build with ESLint dependency
- [ ] Test with videos that have:
  - Multiple audio tracks with different languages
  - Embedded subtitles
  - Embedded thumbnails
  - Missing metadata fields

## Technical Notes

This enhancement provides better visibility into the actual media file composition, which is particularly useful when:
- Verifying subtitle embedding worked correctly
- Checking which audio/subtitle languages are available
- Understanding the complete media container structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)