### PR TITLE
Add custom yt-dlp extractor arguments support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,183 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v0.5.8-bmcd03] - 2025-11-14
+
+### Added
+- **Custom yt-dlp Extractor Arguments Support** - Added ability to pass extractor-specific parameters to yt-dlp at runtime
+  - New `extractor_args` configuration field in Downloads settings
+  - Implemented `ExtractorArgsParser` class following yt-dlp's official parsing logic
+  - Supports multiple extractors, multiple arguments, and complex value formats
+  - Format: `EXTRACTOR1:ARG1=VAL1,VAL2;ARG2=VAL3 EXTRACTOR2:ARG3=VAL4`
+  - Automatic parsing and merging into yt-dlp's extractor_args option
+  - Comprehensive logging of applied arguments for debugging
+  - Commits: 3f529bdb, daf38fc0, 52122123, 35a81a6b, 840c001e, 255b5535, 7e64e451, f812375a, 0ac0efaf, 2979399f
+
+### Technical Details
+
+#### Parser Implementation
+Based on yt-dlp's official parsing logic from [options.py](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/options.py):
+```python
+_extractor_arg_parser = lambda key, vals='': (key.strip().lower().replace('-', '_'), [
+    val.replace(r'\,', ',').strip() for val in re.split(r'(?<!\\),', vals)])
+```
+
+**Features:**
+- Whitespace separates multiple extractors
+- Colon (`:`) separates extractor name from arguments
+- Semicolon (`;`) separates multiple key-value pairs
+- Equals (`=`) separates key from values
+- Comma (`,`) separates multiple values
+- Escaped commas (`\,`) preserved in values
+- Keys normalized: lowercase, hyphens to underscores
+- Helpful warnings for malformed input
+
+#### Files Modified
+**Backend:**
+- `backend/appsettings/serializers.py` - Added extractor_args field
+- `backend/appsettings/src/config.py` - Added to downloads configuration
+- `backend/download/src/yt_dlp_base.py` - ExtractorArgsParser class and YtWrap integration
+- `backend/user/migrations/0001_initial.py` - Migration updates
+
+**Frontend:**
+- `frontend/package.json` - Dependency updates
+- `frontend/package-lock.json` - Updated lockfile
+- `frontend/src/api/loader/loadAppsettingsConfig.ts` - Type definition
+- `frontend/src/pages/SettingsApplication.tsx` - UI input field with help text
+- `frontend/src/stores/AppSettingsStore.ts` - State management
+
+#### Use Cases
+- **PO Token providers** - Integration with bgutil-ytdlp-pot-provider for YouTube rate limiting
+- **Site-specific authentication** - Pass credentials or tokens to extractors
+- **Rate limiting control** - Configure extractor-specific rate limits
+- **Language preferences** - Specify metadata extraction languages
+- **Player client selection** - Choose specific player clients (e.g., `youtube:player_client=android`)
+- **Advanced options** - Enable experimental features or specific extraction modes
+
+#### Example Configurations
+```
+youtubepot-bgutilhttp:base_url=http://172.17.0.1:4416
+youtube:lang=en,es;skip=hls
+youtube:player_client=android generic:key=value
+```
+
+#### Logging Output
+```
+[extractor_args] Applied custom args: {'youtubepot-bgutilhttp': {'base_url': ['http://172.17.0.1:4416']}}
+```
+
+---
+
+## [v0.5.8-bmcd02] - 2025-11-13
+
+### Added
+- **Enhanced Media Stream Metadata Display** - Significantly improved media stream information on video pages
+  - Added subtitle stream detection and display
+  - Added thumbnail stream detection (attached_pic)
+  - Added language metadata for video, audio, and subtitle streams
+  - Improved conditional rendering in frontend for different stream types
+  - Better handling of streams without bitrate data
+  - Commits: 7d66f8bc
+
+### Changed
+- **Frontend Tooling** - Added missing `@eslint/js` v9.33.0 dependency for ESLint support
+  - Commits: c18aff4c
+
+### Technical Details
+
+#### Files Modified
+**Backend:**
+- `backend/video/serializers.py` - Updated StreamItemSerializer to support subtitle type and language field
+- `backend/video/src/media_streams.py` - Added subtitle/thumbnail extraction, language metadata
+
+**Frontend:**
+- `frontend/package.json` - Added @eslint/js dependency
+- `frontend/src/pages/Home.tsx` - Updated StreamType TypeScript definitions
+- `frontend/src/pages/Video.tsx` - Enhanced stream display with conditional rendering
+
+#### Benefits
+- Users can now see all embedded streams (video, audio, subtitles, thumbnails)
+- Language information helps identify multi-language content
+- More robust handling of various media container formats
+- Complements the subtitle embedding feature by showing which subtitles are present
+
+---
+
+## [v0.5.8-bmcd01] - 2025-11-13
+
+### Added
+- **Subtitle Embedding Feature** - Added ability to embed downloaded subtitles directly into MP4 video files
+  - New `add_subtitles` configuration option in Downloads settings
+  - Implemented FFmpegEmbedSubtitle postprocessor in yt-dlp handler
+  - Added toggle control in Settings → Application page
+  - Subtitle embedding is disabled by default for backwards compatibility
+  - Commits: cf3b3891
+
+### Fixed
+- **Query Variable Bug** - Fixed incorrect variable reference (`query` → `queries`) in channel video query logic that could cause AttributeError
+  - File: `backend/channel/src/remote_query.py`
+  - Commits: 47b4332e
+
+- **Download Progress Safety** - Added defensive programming to prevent KeyError when processing yt-dlp responses
+  - Now uses `.get()` method with fallback to "Processing" instead of direct dictionary access
+  - Prevents crashes when `info_dict` or `title` is unavailable during download progress updates
+  - File: `backend/download/src/yt_dlp_handler.py`
+  - Commits: c7905309
+
+### Changed
+- **Frontend Tooling** - Added missing `@eslint/js` v9.33.0 dependency for ESLint support
+  - Improved code formatting consistency
+  - Commits: c800c278
+
+### Technical Details
+
+#### Files Modified
+**Backend:**
+- `backend/appsettings/serializers.py` - Added `add_subtitles` field
+- `backend/appsettings/src/config.py` - Added subtitle embedding configuration
+- `backend/download/src/yt_dlp_handler.py` - Implemented subtitle embedding logic and safety improvements
+- `backend/channel/src/remote_query.py` - Fixed variable reference bug
+
+**Frontend:**
+- `frontend/package.json` - Added @eslint/js dependency
+- `frontend/package-lock.json` - Updated lockfile
+- `frontend/src/api/loader/loadAppsettingsConfig.ts` - Added TypeScript type for add_subtitles
+- `frontend/src/stores/AppSettingsStore.ts` - Added state management for subtitle embedding
+- `frontend/src/pages/SettingsApplication.tsx` - Added UI toggle and formatting improvements
+
+#### Migration Notes
+- No database migrations required
+- New `add_subtitles` setting defaults to `false` (disabled)
+- Existing configurations will continue to work without changes
+
+## [v0.5.8] - 2025-11-07
+
+### Added
+- Thread-safe startup timestamp handling
+- Full metadata embedding functionality
+- Deno support added to build process
+- Frontend caching reload improvements
+
+### Changed
+- Bumped Django version for security updates
+- Updated frontend dependencies
+- Pinned yt-dlp to master branch
+
+### Fixed
+- Fixed unittest failures in startup timestamp handling
+- Fixed embed error handling
+- Fixed upload_date format handling (#1052)
+
+---
+
+## Previous Versions
+
+For changes in versions prior to v0.5.8-bmcd03, please refer to the git commit history or original upstream repository.
+
+---
+
+**Note:** This changelog tracks changes specific to the bmcdonough fork. For upstream Tube Archivist changes, see the [official repository](https://github.com/tubearchivist/tubearchivist).

--- a/backend/appsettings/serializers.py
+++ b/backend/appsettings/serializers.py
@@ -57,6 +57,7 @@ class AppConfigDownloadsSerializer(
     cookie_import = serializers.BooleanField()
     potoken = serializers.BooleanField()
     throttledratelimit = serializers.IntegerField(allow_null=True)
+    extractor_args = serializers.CharField(allow_null=True)
     extractor_lang = serializers.CharField(allow_null=True)
     integrate_ryd = serializers.BooleanField()
     integrate_sponsorblock = serializers.BooleanField()

--- a/backend/appsettings/src/config.py
+++ b/backend/appsettings/src/config.py
@@ -95,6 +95,7 @@ class AppConfig:
             "cookie_import": False,
             "potoken": False,
             "throttledratelimit": None,
+            "extractor_args": None,
             "extractor_lang": None,
             "integrate_ryd": False,
             "integrate_sponsorblock": False,

--- a/backend/appsettings/src/config.py
+++ b/backend/appsettings/src/config.py
@@ -44,6 +44,7 @@ class DownloadsConfigType(TypedDict):
     cookie_import: bool
     potoken: bool
     throttledratelimit: int | None
+    extractor_args: str | None
     extractor_lang: str | None
     integrate_ryd: bool
     integrate_sponsorblock: bool

--- a/backend/download/src/yt_dlp_base.py
+++ b/backend/download/src/yt_dlp_base.py
@@ -30,11 +30,12 @@ class ExtractorArgsParser:
     Example:
         >>> parser = ExtractorArgsParser()
         >>> result = parser.parse("youtube:key1=val1,val2;key2=val3")
-        >>> # Returns: {"youtube": {"key1": ["val1", "val2"], "key2": ["val3"]}}
+        >>> # Returns: {"youtube": {"key1": ["val1", "val2"],
+        >>> #              "key2": ["val3"]}}
     """
 
     @staticmethod
-    def _parse_key_values(key, vals=''):
+    def _parse_key_values(key, vals=""):
         """
         Parse a single key=values pair following yt-dlp logic.
 
@@ -46,7 +47,7 @@ class ExtractorArgsParser:
             tuple: (normalized_key, list_of_values)
         """
         # Normalize key: strip, lowercase, replace hyphens with underscores
-        normalized_key = key.strip().lower().replace('-', '_')
+        normalized_key = key.strip().lower().replace("-", "_")
 
         # Split values by comma, but preserve escaped commas
         # yt-dlp uses: re.split(r'(?<!\\),', vals)
@@ -54,8 +55,8 @@ class ExtractorArgsParser:
             return normalized_key, []
 
         value_list = [
-            val.replace(r'\,', ',').strip()
-            for val in re.split(r'(?<!\\),', vals)
+            val.replace(r"\,", ",").strip()
+            for val in re.split(r"(?<!\\),", vals)
         ]
 
         return normalized_key, value_list
@@ -86,15 +87,21 @@ class ExtractorArgsParser:
 
         for spec in extractor_specs:
             # Split by first colon to separate extractor from args
-            if ':' not in spec:
-                print(f"[extractor_args] Warning: Invalid format (missing colon): {spec}")
+            if ":" not in spec:
+                print(
+                    "[extractor_args] Warning: Invalid format "
+                    f"(missing colon): {spec}"
+                )
                 continue
 
-            extractor_name, args_part = spec.split(':', 1)
+            extractor_name, args_part = spec.split(":", 1)
             extractor_name = extractor_name.strip()
 
             if not extractor_name:
-                print(f"[extractor_args] Warning: Empty extractor name in: {spec}")
+                print(
+                    "[extractor_args] Warning: Empty extractor name "
+                    f"in: {spec}"
+                )
                 continue
 
             # Initialize extractor dict if not exists
@@ -102,18 +109,21 @@ class ExtractorArgsParser:
                 result[extractor_name] = {}
 
             # Split args by semicolon to get individual key=value pairs
-            key_value_pairs = args_part.split(';')
+            key_value_pairs = args_part.split(";")
 
             for pair in key_value_pairs:
                 if not pair.strip():
                     continue
 
                 # Split by first equals sign
-                if '=' not in pair:
-                    print(f"[extractor_args] Warning: Invalid pair (missing =): {pair}")
+                if "=" not in pair:
+                    print(
+                        "[extractor_args] Warning: Invalid pair "
+                        f"(missing =): {pair}"
+                    )
                     continue
 
-                key_part, value_part = pair.split('=', 1)
+                key_part, value_part = pair.split("=", 1)
                 normalized_key, value_list = self._parse_key_values(
                     key_part, value_part
                 )

--- a/backend/download/src/yt_dlp_base.py
+++ b/backend/download/src/yt_dlp_base.py
@@ -4,6 +4,7 @@ functionality:
 - handle yt-dlp errors
 """
 
+import re
 from datetime import datetime
 from http import cookiejar
 from io import StringIO
@@ -12,6 +13,114 @@ import yt_dlp
 from appsettings.src.config import AppConfig
 from common.src.ta_redis import RedisArchivist
 from django.conf import settings
+
+
+class ExtractorArgsParser:
+    """
+    Parse extractor_args string following yt-dlp format.
+
+    Format: "extractor1:key1=val1,val2;key2=val3 extractor2:key3=val4"
+
+    - Whitespace separates multiple extractors
+    - Colon (:) separates extractor name from key-value pairs
+    - Semicolon (;) separates multiple key-value pairs
+    - Equals (=) separates key from values
+    - Comma (,) separates multiple values (escaped commas \\, are preserved)
+
+    Example:
+        >>> parser = ExtractorArgsParser()
+        >>> result = parser.parse("youtube:key1=val1,val2;key2=val3")
+        >>> # Returns: {"youtube": {"key1": ["val1", "val2"], "key2": ["val3"]}}
+    """
+
+    @staticmethod
+    def _parse_key_values(key, vals=''):
+        """
+        Parse a single key=values pair following yt-dlp logic.
+
+        Args:
+            key: The key name (will be normalized)
+            vals: Comma-separated values (escaped commas preserved)
+
+        Returns:
+            tuple: (normalized_key, list_of_values)
+        """
+        # Normalize key: strip, lowercase, replace hyphens with underscores
+        normalized_key = key.strip().lower().replace('-', '_')
+
+        # Split values by comma, but preserve escaped commas
+        # yt-dlp uses: re.split(r'(?<!\\),', vals)
+        if not vals:
+            return normalized_key, []
+
+        value_list = [
+            val.replace(r'\,', ',').strip()
+            for val in re.split(r'(?<!\\),', vals)
+        ]
+
+        return normalized_key, value_list
+
+    def parse(self, extractor_args_str):
+        """
+        Parse extractor_args string into nested dictionary structure.
+
+        Args:
+            extractor_args_str: String in format "extractor:key=val;key2=val2"
+
+        Returns:
+            dict: Nested dictionary with structure:
+                  {extractor_name: {key: [values]}}
+
+        Example:
+            >>> parser.parse("youtube:lang=en,es;key2=val generic:key3=val3")
+            {'youtube': {'lang': ['en', 'es'], 'key2': ['val']},
+             'generic': {'key3': ['val3']}}
+        """
+        if not extractor_args_str or not extractor_args_str.strip():
+            return {}
+
+        result = {}
+
+        # Split by whitespace to get individual extractor specifications
+        extractor_specs = extractor_args_str.strip().split()
+
+        for spec in extractor_specs:
+            # Split by first colon to separate extractor from args
+            if ':' not in spec:
+                print(f"[extractor_args] Warning: Invalid format (missing colon): {spec}")
+                continue
+
+            extractor_name, args_part = spec.split(':', 1)
+            extractor_name = extractor_name.strip()
+
+            if not extractor_name:
+                print(f"[extractor_args] Warning: Empty extractor name in: {spec}")
+                continue
+
+            # Initialize extractor dict if not exists
+            if extractor_name not in result:
+                result[extractor_name] = {}
+
+            # Split args by semicolon to get individual key=value pairs
+            key_value_pairs = args_part.split(';')
+
+            for pair in key_value_pairs:
+                if not pair.strip():
+                    continue
+
+                # Split by first equals sign
+                if '=' not in pair:
+                    print(f"[extractor_args] Warning: Invalid pair (missing =): {pair}")
+                    continue
+
+                key_part, value_part = pair.split('=', 1)
+                normalized_key, value_list = self._parse_key_values(
+                    key_part, value_part
+                )
+
+                result[extractor_name][normalized_key] = value_list
+
+        return result
 
 
 class YtWrap:
@@ -37,6 +146,7 @@ class YtWrap:
         if self.config:
             self._add_cookie()
             self._add_potoken()
+            self._add_extractor_args()
 
         if getattr(settings, "DEBUG", False):
             del self.obs["quiet"]
@@ -62,6 +172,32 @@ class YtWrap:
                     }
                 }
             )
+
+    def _add_extractor_args(self):
+        """add custom extractor_args from config if present"""
+        extractor_args_str = self.config["downloads"].get("extractor_args")
+        if not extractor_args_str:
+            return
+
+        # Parse the extractor_args string
+        parser = ExtractorArgsParser()
+        parsed_args = parser.parse(extractor_args_str)
+
+        if not parsed_args:
+            return
+
+        # Merge with existing extractor_args if present
+        if "extractor_args" not in self.obs:
+            self.obs["extractor_args"] = {}
+
+        for extractor_name, args_dict in parsed_args.items():
+            if extractor_name not in self.obs["extractor_args"]:
+                self.obs["extractor_args"][extractor_name] = {}
+
+            # Merge the arguments, with parsed args taking precedence
+            self.obs["extractor_args"][extractor_name].update(args_dict)
+
+        print(f"[extractor_args] Applied custom args: {parsed_args}")
 
     def download(self, url):
         """make download request"""

--- a/backend/user/migrations/0001_initial.py
+++ b/backend/user/migrations/0001_initial.py
@@ -39,7 +39,10 @@ class Migration(migrations.Migration):
                     "is_superuser",
                     models.BooleanField(
                         default=False,
-                        help_text="Designates that this user has all permissions without explicitly assigning them.",
+                        help_text=(
+                            "Designates that this user has all permissions "
+                            "without explicitly assigning them."
+                        ),
                         verbose_name="superuser status",
                     ),
                 ),
@@ -49,7 +52,11 @@ class Migration(migrations.Migration):
                     "groups",
                     models.ManyToManyField(
                         blank=True,
-                        help_text="The groups this user belongs to. A user will get all permissions granted to each of their groups.",
+                        help_text=(
+                            "The groups this user belongs to. A user will "
+                            "get all permissions granted to each of their "
+                            "groups."
+                        ),
                         related_name="user_set",
                         related_query_name="user",
                         to="auth.group",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1352,7 +1352,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1410,7 +1409,6 @@
       "integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.0",
         "@typescript-eslint/types": "8.46.0",
@@ -1633,7 +1631,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1930,7 +1927,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2824,7 +2820,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2834,7 +2829,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3129,7 +3123,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3182,7 +3175,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3244,7 +3236,6 @@
       "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -3413,7 +3404,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/src/api/loader/loadAppsettingsConfig.ts
+++ b/frontend/src/api/loader/loadAppsettingsConfig.ts
@@ -25,6 +25,7 @@ export type AppSettingsConfigType = {
     cookie_import: boolean;
     potoken: boolean;
     throttledratelimit: number | null;
+    extractor_args: string | null;
     extractor_lang: string | null;
     integrate_ryd: boolean;
     integrate_sponsorblock: boolean;

--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -55,6 +55,7 @@ const SettingsApplication = () => {
   // Download Format
   const [downloadsFormat, setDownloadsFormat] = useState<string | null>(null);
   const [downloadsFormatSort, setDownloadsFormatSort] = useState<string | null>(null);
+  const [downloadsExtractorArgs, setDownloadsExtractorArgs] = useState<string | null>(null);
   const [downloadsExtractorLang, setDownloadsExtractorLang] = useState<string | null>(null);
   const [embedMetadata, setEmbedMetadata] = useState(false);
   const [embedThumbnail, setEmbedThumbnail] = useState(false);
@@ -113,6 +114,7 @@ const SettingsApplication = () => {
     // Download Format
     setDownloadsFormat(appSettingsConfigData?.downloads.format || null);
     setDownloadsFormatSort(appSettingsConfigData?.downloads.format_sort || null);
+    setDownloadsExtractorArgs(appSettingsConfigData?.downloads.extractor_args || null);
     setDownloadsExtractorLang(appSettingsConfigData?.downloads.extractor_lang || null);
     setEmbedMetadata(appSettingsConfigData?.downloads.add_metadata || false);
     setEmbedThumbnail(appSettingsConfigData?.downloads.add_thumbnail || false);
@@ -450,6 +452,20 @@ const SettingsApplication = () => {
                             target="_blank"
                             href="https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#sorting-formats"
                           >
+                            here
+                          </a>
+                          .
+                        </li>
+                      </ul>
+                    </li>
+                    <li>
+                      Extractor Arguments to be passed at runtime
+                      <ul>
+                        <li>Some extractors accept additional arguments</li>
+                        <li>Format: EXTRACTOR:ARG1=VAL1,VAL2;ARG2=VAL3;ARG3=VAL4</li>
+                        <li>
+                          More details{' '}
+                          <a target="_blank" href="https://github.com/yt-dlp/yt-dlp#extractor-arguments">
                             here
                           </a>
                           .

--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -462,7 +462,12 @@ const SettingsApplication = () => {
                       Extractor Arguments to be passed at runtime
                       <ul>
                         <li>Some extractors accept additional arguments</li>
-                        <li>Format: EXTRACTOR:ARG1=VAL1,VAL2;ARG2=VAL3;ARG3=VAL4</li>
+                        <li>Separate multiple extractors with a space</li>
+                        <li>
+                          <span className="settings-current">
+                            EXTRACTOR1:ARG1=VAL1,VAL2;ARG2=VAL3 EXTRACTOR2:ARG3=VAL4
+                          </span>
+                        </li>
                         <li>
                           More details{' '}
                           <a

--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -465,7 +465,10 @@ const SettingsApplication = () => {
                         <li>Format: EXTRACTOR:ARG1=VAL1,VAL2;ARG2=VAL3;ARG3=VAL4</li>
                         <li>
                           More details{' '}
-                          <a target="_blank" href="https://github.com/yt-dlp/yt-dlp#extractor-arguments">
+                          <a
+                            target="_blank"
+                            href="https://github.com/yt-dlp/yt-dlp#extractor-arguments"
+                          >
                             here
                           </a>
                           .

--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -525,6 +525,19 @@ const SettingsApplication = () => {
               </div>
               <div className="settings-box-wrapper">
                 <div>
+                  <p>Extractor Arguments</p>
+                </div>
+                <InputConfig
+                  type="text"
+                  name="downloads.extractor_args"
+                  value={downloadsExtractorArgs}
+                  setValue={setDownloadsExtractorArgs}
+                  oldValue={appSettingsConfig.downloads.extractor_args}
+                  updateCallback={handleUpdateConfig}
+                />
+              </div>
+              <div className="settings-box-wrapper">
+                <div>
                   <p>Extractor Language</p>
                 </div>
                 <InputConfig

--- a/frontend/src/stores/AppSettingsStore.ts
+++ b/frontend/src/stores/AppSettingsStore.ts
@@ -32,6 +32,7 @@ export const useAppSettingsStore = create<AppSettingsState>(set => ({
       cookie_import: false,
       potoken: false,
       throttledratelimit: null,
+      extractor_args: null,
       extractor_lang: null,
       integrate_ryd: false,
       integrate_sponsorblock: false,


### PR DESCRIPTION
## Summary

This PR adds support for custom yt-dlp extractor arguments, allowing users to pass extractor-specific parameters at runtime. This is particularly useful for handling site-specific authentication, rate limiting, or other extractor-specific behaviors.

## Changes

### New Feature: Extractor Arguments Configuration

Implements a complete system for specifying and applying custom arguments to yt-dlp extractors.

**Format:**
```
EXTRACTOR1:ARG1=VAL1,VAL2;ARG2=VAL3 EXTRACTOR2:ARG3=VAL4
```

**Example:**
```
youtube:lang=en,es;skip=hls generic:key=value
```

### Backend Implementation

**ExtractorArgsParser Class (`backend/download/src/yt_dlp_base.py`):**
- Implements robust parsing of extractor argument strings
- Follows yt-dlp's format specification exactly
- Handles multiple extractors separated by whitespace
- Supports multiple key-value pairs per extractor (separated by semicolons)
- Supports multiple values per key (separated by commas)
- Preserves escaped commas in values (`\,`)
- Normalizes keys (lowercase, hyphens to underscores)
- Provides helpful warning messages for malformed input
- Returns nested dictionary structure: `{extractor: {key: [values]}}`

**YtWrap Integration (`backend/download/src/yt_dlp_base.py`):**
- Added `_add_extractor_args()` method to YtWrap class
- Automatically parses and applies extractor_args from config
- Merges with existing extractor_args if present
- Logs applied arguments for debugging

**Configuration (`backend/appsettings/`):**
- Added `extractor_args` field to AppConfig downloads section
- Added serializer field in `serializers.py`
- Defaults to `None` (no custom args)

### Frontend Implementation

**Settings UI (`frontend/src/pages/SettingsApplication.tsx`):**
- Added "Extractor Arguments" input field in Downloads settings
- Includes comprehensive help text with format examples
- Shows example with multiple extractors
- Links to yt-dlp documentation for reference
- Proper state management and update callbacks

**Type Definitions:**
- Updated `AppSettingsConfigType` to include `extractor_args` field
- Updated `AppSettingsStore` with default value

### Files Modified

**Backend:**
- `backend/appsettings/serializers.py` - Added extractor_args field
- `backend/appsettings/src/config.py` - Added to downloads config
- `backend/download/src/yt_dlp_base.py` - ExtractorArgsParser class and integration
- `backend/user/migrations/0001_initial.py` - Migration updates

**Frontend:**
- `frontend/src/api/loader/loadAppsettingsConfig.ts` - Type definition
- `frontend/src/pages/SettingsApplication.tsx` - UI component
- `frontend/src/stores/AppSettingsStore.ts` - State management
- `frontend/package-lock.json` - Dependency updates

## Use Cases

This feature is valuable for:

1. **Site-specific authentication** - Pass credentials or tokens to specific extractors
2. **Rate limiting control** - Configure rate limit parameters for extractors that support it
3. **Language preferences** - Specify preferred languages for metadata extraction
4. **Advanced extraction options** - Enable experimental features or specific extraction modes
5. **Troubleshooting** - Apply debug flags to specific extractors

## Technical Details

### Parser Implementation

The parser follows yt-dlp's specification:
- **Extractor separation**: Whitespace
- **Name-args separation**: Colon (`:`)
- **Key-value pairs**: Semicolon (`;`)
- **Key-values separation**: Equals (`=`)
- **Multiple values**: Comma (`,`)
- **Escaped commas**: Backslash-comma (`\,`) preserved in values

### Integration Flow

1. User enters extractor_args string in Settings
2. Configuration saved to backend
3. On download, YtWrap reads extractor_args from config
4. ExtractorArgsParser parses string into dict structure
5. Parsed args merged into yt-dlp's `extractor_args` option
6. yt-dlp applies args to matching extractors during download

## Test Plan

- [ ] Test with single extractor, single argument
- [ ] Test with single extractor, multiple arguments
- [ ] Test with multiple extractors
- [ ] Test with comma-separated values
- [ ] Test with escaped commas in values
- [ ] Test with empty/null extractor_args (should work normally)
- [ ] Test with malformed input (should log warnings, continue gracefully)
- [ ] Verify args are properly passed to yt-dlp
- [ ] Test UI input and state management
- [ ] Verify help text is clear and accurate

## Documentation

The Settings page includes comprehensive help text:
- Format specification with examples
- Multiple extractor example
- Link to yt-dlp documentation
- Clear separation of multiple extractors

## Safety Considerations

- Empty or null values are handled gracefully
- Malformed input generates warnings but doesn't break downloads
- Invalid formats are logged for user debugging
- No validation of extractor names (deferred to yt-dlp)
- No validation of argument names/values (deferred to yt-dlp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)